### PR TITLE
Set regular prompt

### DIFF
--- a/roles/core/shell/files/dot.zshrc
+++ b/roles/core/shell/files/dot.zshrc
@@ -12,6 +12,7 @@
 #
 #   :: Completions
 #   :: History
+#   :: Prompt
 #   :: Background jobs
 #   :: Compatibility with csh
 #   :: Keys bindings
@@ -44,6 +45,12 @@ HISTFILE=~/.histfile
 HISTSIZE=10000
 SAVEHIST=10000
 setopt appendhistory
+
+#   -------------------------------------------------------------
+#   Prompt
+#   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+prompt='%B%/%b ] '
 
 #   -------------------------------------------------------------
 #   Background jobs


### PR DESCRIPTION
Same than legacy .cshrc

`/home/dereckson ]`

Hostname isn't needed, as it's published in the tmux bottom right area.